### PR TITLE
feat: add Status Effect Chance

### DIFF
--- a/LibCombat/LibCombat.lua
+++ b/LibCombat/LibCombat.lua
@@ -12,7 +12,7 @@ Add more debug Functions
 ]]
 
 local lib = {}
-lib.version = 87
+lib.version = 88
 LibCombat = lib
 
 -- Basic values
@@ -5312,6 +5312,7 @@ local statStrings = {
 	[LIBCOMBAT_STAT_PHYSICALRESISTANCE] = "|cffff88" .. GetString(SI_DERIVEDSTATS22) .. "|r ",
 	[LIBCOMBAT_STAT_SPELLRESISTANCE] = "|cffff88" .. GetString(SI_DERIVEDSTATS13) .. "|r ",
 	[LIBCOMBAT_STAT_CRITICALRESISTANCE] = "|cffff88" .. GetString(SI_DERIVEDSTATS24) .. "|r ",
+	[LIBCOMBAT_STAT_STATUS_EFFECT_CHANCE] = "|cdddddd" .. GetString(SI_LIBCOMBAT_LOG_STAT_STATUS_EFFECT_CHANCE) .. "|r ",
 }
 
 local logColors = {
@@ -5557,6 +5558,11 @@ function lib:GetCombatLogString(fight, logline, fontsize, showIds)
 		end
 
 		if statId == LIBCOMBAT_STAT_SPELLCRITBONUS or statId == LIBCOMBAT_STAT_WEAPONCRITBONUS then
+			value = stringformat("%.1f%%", newvalue)
+			change = stringformat("%.1f%%", statchange)
+		end
+
+		if statId == LIBCOMBAT_STAT_STATUS_EFFECT_CHANCE then
 			value = stringformat("%.1f%%", newvalue)
 			change = stringformat("%.1f%%", statchange)
 		end

--- a/LibCombat/LibCombat.txt
+++ b/LibCombat/LibCombat.txt
@@ -1,8 +1,8 @@
 ﻿## Title: LibCombat
-## APIVersion: 101048 101049
+## APIVersion: 101049 101050
 ## Author: Solinur
-## Version: 87
-## AddOnVersion: 87
+## Version: 88
+## AddOnVersion: 88
 ## IsLibrary: true
 ## DependsOn: 
 ## OptionalDependsOn: LibDebugLogger

--- a/LibCombat/lang/en.lua
+++ b/LibCombat/lang/en.lua
@@ -23,6 +23,7 @@ local strings = {
 
 	SI_LIBCOMBAT_LOG_STAT_SPELL_CRIT_DONE = "Spell Critical Damage",  -- "Spell Critical Damage"
 	SI_LIBCOMBAT_LOG_STAT_WEAPON_CRIT_DONE = "Physical Critical Damage",  -- "Physical Critical Damage"
+	SI_LIBCOMBAT_LOG_STAT_STATUS_EFFECT_CHANCE = "Status Effect Chance",  -- "Status Effect Chance"
 
 	SI_LIBCOMBAT_LOG_MESSAGE1 = "Entering Combat",  -- "Entering Combat"
 	SI_LIBCOMBAT_LOG_MESSAGE2 = "Exiting Combat",  -- "Exiting Combat"


### PR DESCRIPTION
Fixes missing Status Effect Chance labels in combat log formatting. The defect exists on live; it only surfaced as a blocking assert here because `internalassert` was overridden to `assert`, which exposes `zo_strformat`’s argument validation.

<img width="1140" height="894" alt="image" src="https://github.com/user-attachments/assets/5f80ba19-7109-45d5-b06b-2536b3383c5f" />

```Lua
assert: Argument 2 with invalid type passed to zo_strformat: nil
|rstack traceback:
[C]: in function 'assert'
EsoUI/Libraries/Globals/Localization.lua:44: in function 'zo_strformat'
|caaaaaa<Locals> formatString = "<<1>> Your <<2>> <<3>> |cfffff...", i = 2, currentArgType = "nil" </Locals>|r
EsoUI/Libraries/Globals/Localization.lua:104: in function 'ZO_CachedStrFormat'
|caaaaaa<Locals> formatter = "<<1>> Your <<2>> <<3>> |cfffff...", formatterCache = [table:1]{3650430957 = "|ccccccc[0.000s]|r Your |c8888..."}, concatParams = "|ccccccc[0.000s]|ris at60", hashKey = 959200837 </Locals>|r
user:/AddOns/LibCombat/LibCombat.lua:5578: in function 'lib:GetCombatLogString'
|caaaaaa<Locals> self = [table:2]{totalevents = 370, name = "LibCombat", version = 87, debug = F, _directory = "user:/AddOns/LibCombat/"}, fight = [table:3]{group = F, groupDamageIn = 0, combattime = 209.08, ESOversion = "eso.live.11.3.6.3240040", groupHPSIn = 0, zoneId = 1560, healingInTotal = 1854, dpsstart = 3416830, healingOutTotal = 1854, activetime = 209.076, dataVersion = 2, damageInShielded = 0, hpstime = 176.691, HPSAOut = 481, starttime = 3416830, APIversion = 101049, date = 1779261818, subzone = "", HPSOut = 10, endtime = 3625906, zone = "Hiddenspring Cottage", groupHealingIn = 0, startBar = 2, playerid = 52288, calculating = F, isWipe = F, time = "02:23:38", combatend = 3625909, DPSOut = 100456, groupHealingOut = 0, account = "@dack_janiels", fightlabel = "Unkown", groupDPSIn = 0, DPSIn = 0, groupHPSOut = 0, groupDPSOut = 0, damageOutTotal = 21002944, prepared = T, damageInTotal = 0, combatstart = 3416830, dpstime = 209.076, hpsend = 3594741, hpsstart = 3418050, groupDamageOut = 0, HPSIn = 10, dpsend = 3625906, healingOutAbsolute = 84942, char = "Dak'Janiels"}, logline = [table:4]{1 = 14}, fontsize = 14, showIds = T, logtype = 14, color = [table:5]{1 = 0.8}, timeValue = 0, timeString = "|ccccccc[0.000s]|r", logFormat = "<<1>> Your <<2>> <<3>> |cfffff...", units = [table:6]{}, _ = 14, _ = 3416830, statchange = 0, newvalue = 60, statId = 25, change = 0, value = 60, changeText = "is at", changeValueText = "" </Locals>|r
user:/AddOns/CombatMetrics/CombatMetrics.lua:2631: in function 'CMX.GetCombatLogString'
|caaaaaa<Locals> fight = [table:3], logline = [table:4], fontsize = 14 </Locals>|r
user:/AddOns/CombatMetrics/CombatMetricsUI.lua:3648: in function 'updateCombatLog'
|caaaaaa<Locals> panel = ud, CLSelection = [table:7]{16 = T}, window = ud, copyPasteBox = ud, buffer = ud, slider = ud, logdata = [table:8]{}, loglength = 17896, isCopyPasteMode = F, lastLine = 0, firstLine = -20, copyPasteText = [table:9]{}, maxpage = 18, page = 1, writtenlines = 34, unitSelection = [table:10]{}, abilitySelection = [table:11]{}, unitSelectionAll = [table:12]{52288 = 1}, unitsSelected = T, k = 34 </Locals>|r
user:/AddOns/CombatMetrics/CombatMetricsUI.lua:369: in function 'selectMainPanel'
|caaaaaa<Locals> button = ud, selectControl = ud, category = "CombatLog", mainPanel = ud, rightPanel = ud, unitPanel = ud, abilityPanel = ud, infoPanel = ud, graphPanel = ud, isInfo = F, isGraph = F, selected = ud </Locals>|r
```